### PR TITLE
Add option to display notes in French notation

### DIFF
--- a/src/App.ml
+++ b/src/App.ml
@@ -136,7 +136,7 @@ let update model = function
     let play_note _ =
       match note with
       | Note.Rest | Note.Hold -> ()
-      | _ -> player |. Player.play_no_callback (Note.string_of_note note)
+      | _ -> player |. Player.play_no_callback (Note.string_of_note note).en
     in
     model, Cmd.call play_note
   | ShowInfo modal_visible -> { model with modal_visible }, Cmd.none
@@ -213,6 +213,7 @@ let view model =
         ~selected_index:model.selected_index
         ~playing_index:model.playing_index
         ~title:model.title
+        ~lang:Note.I18n.En
     ; (if model.modal_visible then modal else noNode)
     ; div
         [ class' "ac-controls" ]

--- a/src/App.ml
+++ b/src/App.ml
@@ -90,6 +90,7 @@ let update model = function
     in
     { model with selected_index = Some index }, cmd
   | UpdateTune tune -> { model with tune }, Cmd.msg Stop
+  | SetLanguage lang -> { model with lang }, Task.ignore (AppTask.set_lang lang)
   | KeyPressed key ->
     let maybe_update_note dir =
       match model.selected_index with

--- a/src/App.ml
+++ b/src/App.ml
@@ -157,7 +157,24 @@ let onClickStopPropagation msg =
     (Tea.Json.Decoder.succeed msg)
 ;;
 
-let modal =
+let modal selected_lang =
+  let lang_select lang =
+    let lang_str = I18n.Lang.to_string lang in
+    [ input'
+        [ type' "radio"
+        ; name "lang"
+        ; id lang_str
+        ; value lang_str
+        ; checked (lang = selected_lang)
+        ; onClick (Msg.SetLanguage lang)
+        ]
+        []
+    ; label [ for' lang_str ] [ text lang_str ]
+    ]
+  in
+  let lang_radio_buttons =
+    [ I18n.Lang.En; I18n.Lang.Fr ] |> List.map lang_select |> List.flatten
+  in
   div
     ~key:""
     [ class' "ac-modal__bg"; onClick (Msg.ShowInfo false) ]
@@ -184,16 +201,20 @@ let modal =
                  pre-loaded), to make it easier for others to play it."
             ]
         ; div
-            [ class' "ac-modal__footer" ]
-            [ a
-                [ href "https://twitter.com/walfieee/status/1240718100460273665"
-                ; target "_blank"
+            [ class' "ac-modal-footer" ]
+            [ div [ class' "ac-modal-footer__item" ] lang_radio_buttons
+            ; div
+                [ class' "ac-modal-footer__item ac-modal-footer__item--links" ]
+                [ a
+                    [ href "https://twitter.com/walfieee/status/1240718100460273665"
+                    ; target "_blank"
+                    ]
+                    [ text "Twitter" ]
+                ; text {js|  · |js}
+                ; a
+                    [ href "https://github.com/walfie/ac-tune-maker"; target "_blank" ]
+                    [ text "GitHub" ]
                 ]
-                [ text "Twitter" ]
-            ; text {js|  · |js}
-            ; a
-                [ href "https://github.com/walfie/ac-tune-maker"; target "_blank" ]
-                [ text "GitHub" ]
             ]
         ]
     ; div [ class' "ac-modal__pad-end" ] []
@@ -217,7 +238,7 @@ let view model =
         ~playing_index:model.playing_index
         ~title:model.title
         ~lang:model.lang
-    ; (if model.modal_visible then modal else noNode)
+    ; (if model.modal_visible then modal model.lang else noNode)
     ; div
         [ class' "ac-controls" ]
         [ input'

--- a/src/AppTask.ml
+++ b/src/AppTask.ml
@@ -1,6 +1,11 @@
 open Binding
 open Tea
 
+let set_lang (lang : I18n.Lang.t) =
+  let _ = I18n.Lang.to_string lang |> LocalStorage.setItem "lang" in
+  Task.succeed ()
+;;
+
 let set_document_title (title : string) =
   let _ = Dom.(document |. setTitle {j|$title - Animal Crossing Tune Maker|j}) in
   Task.succeed ()

--- a/src/Binding.ml
+++ b/src/Binding.ml
@@ -17,6 +17,10 @@ module Player = struct
   external play_no_callback : player -> string -> unit = "play" [@@bs.send]
 end
 
+module LocalStorage = struct
+  external setItem : string -> string -> unit = "setItem" [@@bs.val] [@@bs.scope "window"]
+end
+
 module Dom = struct
   type element
 

--- a/src/Binding.ml
+++ b/src/Binding.ml
@@ -18,7 +18,8 @@ module Player = struct
 end
 
 module LocalStorage = struct
-  external setItem : string -> string -> unit = "setItem" [@@bs.val] [@@bs.scope "window"]
+  external setItem : string -> string -> unit = "setItem"
+    [@@bs.val] [@@bs.scope "window", "localStorage"]
 end
 
 module Dom = struct

--- a/src/FrogSvg.ml
+++ b/src/FrogSvg.ml
@@ -12,19 +12,20 @@ let classes classes =
 ;;
 
 let frog_svg
+    (lang : I18n.lang)
     (index : Tune.Index.t)
     (note : Note.note)
     (is_large : bool)
     (is_selected : bool)
   =
+  let meta = Note.meta note in
   let note_href, note_class, note_text =
     match note with
     | Hold -> "#frog-hold", "frog__text", {js|—|js}
     | Rest -> "#frog-rest", "frog__text", ""
     | Random -> "#frog-random", "frog__text frog__text--large", "?"
-    | other -> "#frog-normal", "frog__text", string_of_note other
+    | other -> "#frog-normal", "frog__text", meta.as_str |> I18n.get lang
   in
-  let meta = Note.meta note in
   let y_offset = meta.index * -15 in
   let y_offset_prop = y (string_of_int y_offset) in
   let hand =
@@ -75,12 +76,16 @@ let move_to_end index input_list =
   | _ -> input_list
 ;;
 
-let note_picker (current_note : Note.note option) (selected_index : Tune.Index.t) =
+let note_picker
+    (lang : I18n.lang)
+    (current_note : Note.note option)
+    (selected_index : Tune.Index.t)
+  =
   let to_elem note =
     let meta = Note.meta note in
     let x_pos = meta.index * 150 in
     let update_note = Msg.updateNote selected_index (Msg.Direction.Set note) in
-    let letter = if note = Note.Random then "?" else meta.as_str in
+    let letter = if note = Note.Random then "?" else meta.as_str |> I18n.get lang in
     let current_indicator =
       if current_note = Some note
       then rect [ class' "note_picker__current"; fill meta.color ] []
@@ -131,6 +136,7 @@ let bg_svg
     ~(selected_index : Tune.Index.t option)
     ~(playing_index : Tune.Index.t option)
     ~(title : Msg.Title.t)
+    ~(lang : I18n.lang)
   =
   let current_note = Belt.Option.map selected_index (fun n -> Tune.get n tune) in
   let make_frog index note =
@@ -140,7 +146,7 @@ let bg_svg
       | None -> is_selected
       | Some i -> index = i
     in
-    frog_svg index note is_large is_selected
+    frog_svg lang index note is_large is_selected
   in
   let positioned_frog index frog =
     let x = index mod 8 * 345 in
@@ -156,7 +162,7 @@ let bg_svg
     | Some index -> frogs |> move_to_end (Tune.Index.to_int index)
   in
   let note_picker_elem =
-    selected_index |. Belt.Option.mapWithDefault noNode (note_picker current_note)
+    selected_index |. Belt.Option.mapWithDefault noNode (note_picker lang current_note)
   in
   svg
     [ class' "ac-main js-svg-main"; viewBox viewBoxString ]

--- a/src/FrogSvg.ml
+++ b/src/FrogSvg.ml
@@ -12,7 +12,7 @@ let classes classes =
 ;;
 
 let frog_svg
-    (lang : I18n.lang)
+    (lang : I18n.Lang.t)
     (index : Tune.Index.t)
     (note : Note.note)
     (is_large : bool)
@@ -77,7 +77,7 @@ let move_to_end index input_list =
 ;;
 
 let note_picker
-    (lang : I18n.lang)
+    (lang : I18n.Lang.t)
     (current_note : Note.note option)
     (selected_index : Tune.Index.t)
   =
@@ -136,7 +136,7 @@ let bg_svg
     ~(selected_index : Tune.Index.t option)
     ~(playing_index : Tune.Index.t option)
     ~(title : Msg.Title.t)
-    ~(lang : I18n.lang)
+    ~(lang : I18n.Lang.t)
   =
   let current_note = Belt.Option.map selected_index (fun n -> Tune.get n tune) in
   let make_frog index note =

--- a/src/FrogSvg.ml
+++ b/src/FrogSvg.ml
@@ -24,7 +24,7 @@ let frog_svg
     | Hold -> "#frog-hold", "frog__text", {js|—|js}
     | Rest -> "#frog-rest", "frog__text", ""
     | Random -> "#frog-random", "frog__text frog__text--large", "?"
-    | other -> "#frog-normal", "frog__text", meta.as_str |> I18n.get lang
+    | _ -> "#frog-normal", "frog__text", meta.as_str |> I18n.get lang
   in
   let y_offset = meta.index * -15 in
   let y_offset_prop = y (string_of_int y_offset) in

--- a/src/I18n.ml
+++ b/src/I18n.ml
@@ -1,0 +1,22 @@
+module Lang = struct
+  type t =
+    | En
+    | Fr
+
+  let from_string s =
+    match Js.String.split "-" s |. Js.Array.unsafe_get 0 with
+    | "fr" -> Fr
+    | _ -> En
+  ;;
+end
+
+type t =
+  { en : string
+  ; fr : string
+  }
+
+let get lang v =
+  match lang with
+  | Lang.En -> v.en
+  | Lang.Fr -> v.fr
+;;

--- a/src/I18n.ml
+++ b/src/I18n.ml
@@ -8,6 +8,11 @@ module Lang = struct
     | "fr" -> Fr
     | _ -> En
   ;;
+
+  let to_string = function
+    | Fr -> "fr"
+    | En -> "en"
+  ;;
 end
 
 type t =

--- a/src/I18n.mli
+++ b/src/I18n.mli
@@ -1,0 +1,12 @@
+module Lang : sig
+  type t
+
+  val from_string : string -> t
+end
+
+type t =
+  { en : string
+  ; fr : string
+  }
+
+val get : Lang.t -> t -> string

--- a/src/I18n.mli
+++ b/src/I18n.mli
@@ -2,6 +2,7 @@ module Lang : sig
   type t
 
   val from_string : string -> t
+  val to_string : t -> string
 end
 
 type t =

--- a/src/I18n.mli
+++ b/src/I18n.mli
@@ -1,5 +1,7 @@
 module Lang : sig
-  type t
+  type t =
+    | En
+    | Fr
 
   val from_string : string -> t
   val to_string : t -> string

--- a/src/Msg.ml
+++ b/src/Msg.ml
@@ -29,4 +29,5 @@ type t =
   | PromptTitle
   | UpdateTitle of Title.t
   | UrlChange of Web.Location.location
+  | SetLanguage of I18n.Lang.t
 [@@bs.deriving { accessors }]

--- a/src/Note.ml
+++ b/src/Note.ml
@@ -1,27 +1,3 @@
-module type I18n = sig
-  type lang
-  type t
-
-  val get : lang -> t -> string
-end
-
-module I18n = struct
-  type lang =
-    | En
-    | Fr
-
-  type t =
-    { en : string
-    ; fr : string
-    }
-
-  let get lang v =
-    match lang with
-    | En -> v.en
-    | Fr -> v.fr
-  ;;
-end
-
 type note =
   | Rest
   | Hold
@@ -53,6 +29,7 @@ let random () = Js.Array.length all |> Js.Math.random_int 0 |> Js.Array.unsafe_g
 
 let meta n =
   let m index (en, fr) color next prev =
+    let open I18n in
     { index; as_str = { en; fr }; color; next; prev }
   in
   match n with

--- a/src/Tune.ml
+++ b/src/Tune.ml
@@ -32,7 +32,7 @@ let from_string (str : string) : t =
 
 let to_string (tune : t) : string =
   tune
-  |> List.map Note.string_of_note
+  |> List.map (fun n -> (Note.string_of_note n).en)
   |> String.concat ""
   |. Js.String.slice ~from:0 ~to_:length
 ;;

--- a/src/index.js
+++ b/src/index.js
@@ -28,11 +28,14 @@ const run = model => {
 let app = run();
 
 if (module.hot) {
-  module.hot.accept(["./App.bs", "../static/frogs.svg"], () => {
-    app.shutdown().then(model => {
-      app = run(model);
-    });
-  });
+  module.hot.accept(
+    ["./App.bs", "../static/frogs.svg", "../static/style.css"],
+    () => {
+      app.shutdown().then(model => {
+        app = run(model);
+      });
+    }
+  );
 }
 
 if ("serviceWorker" in navigator) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,20 @@ const svgContainer = (() => {
   return div;
 })();
 
+const getLanguage = () => {
+  return (
+    localStorage.getItem("lang") ||
+    (navigator.languages && navigator.languages[0]) ||
+    navigator.language ||
+    "en-US"
+  );
+};
+
 const run = model => {
   svgContainer.innerHTML = frogSvg;
   svgContainer.querySelector("svg").setAttribute("class", "js-svg-defs");
 
-  return main(document.getElementById("app"), model);
+  return main(document.getElementById("app"), getLanguage(), model);
 };
 
 let app = run();

--- a/static/frogs.svg
+++ b/static/frogs.svg
@@ -69,7 +69,7 @@ text {
 .frog__text {
   user-select: none;
   fill: #3d2700;
-  font-size: 135px;
+  font-size: 130px;
   font-weight: bold;
   text-anchor: middle;
   transform: translate(150px, 215px);

--- a/static/frogs.svg
+++ b/static/frogs.svg
@@ -201,7 +201,7 @@ text {
   pointer-events: none;
   user-select: none;
   fill: #f9fbe2;
-  font-size: 100px;
+  font-size: 85px;
   mix-blend-mode: lighten;
   transform: translate(0, 35px);
   font-weight: bold;

--- a/static/style.css
+++ b/static/style.css
@@ -195,14 +195,27 @@ body,
   font-size: 1.3em;
 }
 
-.ac-modal__footer {
+.ac-modal-footer {
   border-top: 2px dashed #b8b49b;
   padding: 15px 10px 0 10px;
-  text-align: right;
+  display: flex;
 }
 
-.ac-modal__footer a {
+.ac-modal-footer a {
   font-weight: bold;
   color: #4c3d3c;
   text-decoration: none;
+}
+
+.ac-modal-footer label {
+  padding: 0 8px 0 2px;
+  text-transform: uppercase;
+}
+
+.ac-modal-footer__item {
+  flex-basis: 50%;
+}
+
+.ac-modal-footer__item--links {
+  text-align: right;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,13 @@ const webpackConfig = {
     rules: [
       {
         test: /\.css$/,
-        use: [MiniCssExtractPlugin.loader, "css-loader"]
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: { hmr: !isProd }
+          },
+          "css-loader"
+        ]
       },
       {
         test: /\.svg$/,


### PR DESCRIPTION
Adds a `lang` field to the model which is initialized by either a value
in `localStorage`, or the user's configured language preference in
`navigator.languages` (or `navigator.language`). The option can be
changed in the `...` modal.

![ac_tune_maker_lang_select](https://user-images.githubusercontent.com/11370525/80322426-0c37af00-87f3-11ea-9d8b-690001eb57a4.gif)

Closes #9 